### PR TITLE
fix: spam of selecting player when none available

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -41,10 +41,11 @@ func Execute(_ *cobra.Command, _ []string) {
 	var mprisPlayer *mpris.Player
 	for mprisPlayer == nil {
 		p, _, err := player.Select(conn)
-		if err == nil {
+		if err != nil {
 			slog.Debug("Failed to select player", "error", err)
-			mprisPlayer = p
+			time.Sleep(SleepTime)
 		}
+		mprisPlayer = p
 	}
 	slog.Debug("Player selected", "player", mprisPlayer)
 


### PR DESCRIPTION
when spotify hasn't been launched yet (or probably whatever player is supported), dbus can't find a player and the current code spams requests to dbus asking it for a new player. this causes like ~7% cpu per waybar-lyric process and ~0.8% for the dbus-broker.

this pr just uses the `SleepTime` var you set to wait a bit per request.

also thank you for this repo! it works really well for my hyprland setup