### PR TITLE
fix: only handle SIGKILL and SIGTERM

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,12 +29,7 @@ func main() {
 		context.Background(),
 		cmd.Command,
 		fang.WithFlagTypes(),
-		fang.WithNotifySignal(
-			os.Interrupt,
-			os.Kill,
-			syscall.SIGKILL,
-			syscall.SIGTERM,
-		),
+		fang.WithNotifySignal(syscall.SIGINT, syscall.SIGTERM),
 		fang.WithVersion(GetASCII()),
 		fang.WithoutCompletions(),
 		fang.WithoutManpage(),


### PR DESCRIPTION
This patch ensure only handle SIGTERM (15) the default signal for kill
command and SIGINT (2) the ctrl+c signal. Since, SIGKILL has been
removed since that means immediate cancellation.
