### PR TITLE
Remove noise in logs for songs without lyrics/found lyrics

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -136,11 +137,15 @@ func Execute(cmd *cobra.Command, _ []string) error {
 			w.Encode()
 			lyrics, err = lyric.GetLyrics(ctx, info)
 			if err != nil {
-				slog.Error(
-					"Failed to get lyrics",
-					"error", err,
-					"lines", lyrics.Lines,
-				)
+				if errors.Is(err, lyric.ErrLyricsNotFound) {
+					slog.Info("Lyrics not found")
+				} else {
+					slog.Error(
+						"Failed to get lyrics",
+						"error", err,
+						"lines", lyrics.Lines,
+					)
+				}
 			}
 		}
 


### PR DESCRIPTION
# Summary
Changes the logging behavior when lyrics are unavailable from ERROR to INFO level, reducing log noise. Also removes error logging that was treating empty lyrics as an error condition.

# Problem
The module had two issues with error logging:

- Logging 404 responses from lrclib as errors, creating unnecessary noise when:
  - The track is instrumental (no lyrics exist)
  - The song isn't in lrclib's database
  - The track is a non-vocal music piece

- Error logging after the fetch attempt that would log again even when the issue was already handled, and would incorrectly treat err == nil with empty lyrics as an error.

# Changes
- Changed logging level from ERROR to INFO when lyrics are not found (404)
- Actual errors (network issues, 5xx responses, parsing failures) still logged as ERROR
- Moved error logging block that was incorrectly treating empty results as errors even when err == nil

# Impact
- Significantly reduces log noise in normal operation
- Eliminates false-positive error logs when lyrics are legitimately unavailable
- Makes it easier to identify actual problems in logs
- Better semantic logging (INFO for "data not available", ERROR for "something broke")


# Commits:

- 07b2d01 - Initial fix to stop logging error when lyrics missing
- d5239b9 - Refined approach and removed duplicate error logging