### PR TITLE
Add --ignore-album flag for lyric search

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,8 @@ func init() {
 	Command.Flags().
 		BoolVarP(&config.ExperimentalChromiumSupport, "experimental-chromium-support", "x", config.ToggleState, "Enable experimental chromium support.")
 	Command.Flags().
+		BoolVarP(&config.IgnoreAlbum, "ignore-album", "a", config.IgnoreAlbum, "Ignore album when searching for lyrics")
+	Command.Flags().
 		IntVarP(&config.BreakTooltip, "break-tooltip", "b", config.BreakTooltip, "Break long lines in tooltip")
 	Command.Flags().
 		IntVarP(&config.MaxTextLength, "max-length", "m", config.MaxTextLength, "Set maximum character length for lyrics text")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ var (
 	Verbose         = false
 	Quiet           = false
 	LyricOnly       = false
+	IgnoreAlbum     = false
 	Compact         = false
 	Detailed        = false
 	BreakTooltip    = 100000

--- a/internal/lyric/provider/lrclib/lrclib.go
+++ b/internal/lyric/provider/lrclib/lrclib.go
@@ -39,7 +39,7 @@ var Provider = provider.NewProvider("lrclib lyrics api",
 		params := url.Values{}
 		params.Set("track_name", metadata.RawTitle)
 		params.Set("artist_name", metadata.RawArtist)
-		if metadata.Album != "" {
+		if !config.IgnoreAlbum && metadata.Album != "" {
 			params.Set("album_name", metadata.Album)
 		}
 


### PR DESCRIPTION
Currently only set up for lrclib. Adds a `--ignore-album` flag that allows for the `album_name` parameter to be omitted from the API request for lyrics. This fixes occasional issues where lyrics for album versions of songs aren't found properly, but single versions are.