### PR TITLE
chore: remove `--experimental-chromium-support` flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,8 +42,6 @@ func init() {
 	Command.Flags().
 		BoolVarP(&config.ToggleState, "toggle", "t", config.ToggleState, "Toggle player state between pause and resume")
 	Command.Flags().
-		BoolVarP(&config.ExperimentalChromiumSupport, "experimental-chromium-support", "x", config.ToggleState, "Enable experimental chromium support.")
-	Command.Flags().
 		IntVarP(&config.BreakTooltip, "break-tooltip", "b", config.BreakTooltip, "Break long lines in tooltip")
 	Command.Flags().
 		IntVarP(&config.MaxTextLength, "max-length", "m", config.MaxTextLength, "Set maximum character length for lyrics text")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,8 +17,6 @@ var (
 	FilterProfanity = false
 	LogFilePath     = ""
 
-	ExperimentalChromiumSupport = false
-
 	FilterProfanityType = ""
 
 	Version string

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Nadim147c/go-mpris"
-	"github.com/Nadim147c/waybar-lyric/internal/config"
 	"github.com/godbus/dbus/v5"
 )
 
@@ -66,16 +65,6 @@ func Select(conn *dbus.Conn) (*mpris.Player, error) {
 			strings.Contains(host, "open.spotify.com") {
 			slog.Debug("Player selected", "name", "firefox")
 			return player, nil
-		}
-	}
-
-	chromeRe := regexp.MustCompile(`^org\.mpris\.MediaPlayer2\.\w+\.instance\d+$`)
-
-	if config.ExperimentalChromiumSupport {
-		for _, player := range players {
-			if chromeRe.MatchString(player) {
-				return mpris.New(conn, player), nil
-			}
 		}
 	}
 

--- a/result-x86_64-linux.go-format
+++ b/result-x86_64-linux.go-format
@@ -1,1 +1,0 @@
-/nix/store/fn4imrchzmb3nxiyl32kp0vn8a9qr6gb-go-format


### PR DESCRIPTION

Since waybar-lyric supports any player that provides
artists and album, this flag is useless!
